### PR TITLE
Fix favicon icon typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Francesco Caglianone</title>
-  <link rel="icon" type="image/x-icon" href="./data/mascot.png"">
+  <link rel="icon" type="image/x-icon" href="./data/mascot.png">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.14.0/devicon.min.css">


### PR DESCRIPTION
## Summary
- fix closing quote in favicon link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e0bb37e0c83249c2b709ad35ef02a